### PR TITLE
alpine openjdk8 支援 gRPC

### DIFF
--- a/openjre8/Dockerfile.grpc
+++ b/openjre8/Dockerfile.grpc
@@ -1,0 +1,14 @@
+FROM openjdk:8-alpine
+MAINTAINER softleader.com.tw
+
+# install packages & set timezone: https://wiki.alpinelinux.org/wiki/Setting_the_timezone
+RUN apk update \
+    && apk --no-cache add bash ca-certificates wget tzdata maven \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk \
+    && apk add glibc-2.29-r0.apk \
+    && rm -rf /var/cache/apk/* \
+    && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
+    && echo "Asia/Taipei" > /etc/timezone \
+    && rm /etc/apk/keys/sgerrand.rsa.pub \
+    && apk del ca-certificates wget tzdata


### PR DESCRIPTION
1. alpine linux 裡的 musl libc 未能如期支援 google 的 protoc [issue](https://github.com/xolstice/protobuf-maven-plugin/issues/23)
2. 加入 alpine-pkg-glibc 可以解決 gRPC 不支援問題 [solution](https://github.com/sgerrand/alpine-pkg-glibc)
3. 建議建立的 image 名稱為 softleader/openjdk8:grpc