### PR TITLE
chore: switch nginx base image to nginxinc stable-alpine

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.softleader.com.tw/library/nginx-unprivileged:stable-alpine-1.28.3
+FROM nginxinc/nginx-unprivileged:stable-alpine
 
 USER root
 


### PR DESCRIPTION
## 摘要
- 將 `nginx/Dockerfile` 的 base image 從 `harbor.softleader.com.tw/library/nginx-unprivileged:stable-alpine-1.28.3` 改為 `nginxinc/nginx-unprivileged:stable-alpine`
- 在 upstream stable release 問題仍在追蹤期間，先對齊 upstream 的 unprivileged nginx image 來源

## 驗證
- `docker build -f nginx/Dockerfile .`

## Merge blocker
- 在 upstream issue 關閉前，**不要** merge：https://github.com/nginx/docker-nginx-unprivileged/issues/411
- 在 upstream 正確 release 新 image 並完成驗證前，**不要** merge