### PR TITLE
fix: 修正 GitHub Actions 映像建置

### DIFF
--- a/eclipse-temurin/Dockerfile.11-font-jre-taipei
+++ b/eclipse-temurin/Dockerfile.11-font-jre-taipei
@@ -4,7 +4,7 @@ LABEL maintainer="softleader.com.tw"
 RUN apk update &&\
 	# 避免 upstream 有些 package 沒更新到被掃出風險，這邊強制都 upgrade 一下
 	apk --no-cache upgrade &&\
-    apk --no-cache add curl bash tzdata fontconfig ttf-dejavu &&\
+    apk --no-cache add curl bash tzdata fontconfig ttf-dejavu unzip &&\
     rm -rf /var/cache/apk/* &&\
     cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime &&\
     echo "Asia/Taipei" > /etc/timezone &&\

--- a/eclipse-temurin/Dockerfile.11-jre-taipei
+++ b/eclipse-temurin/Dockerfile.11-jre-taipei
@@ -4,7 +4,7 @@ LABEL maintainer="softleader.com.tw"
 RUN apk update &&\
 	# 避免 upstream 有些 package 沒更新到被掃出風險，這邊強制都 upgrade 一下
 	apk --no-cache upgrade &&\
-    apk --no-cache add curl bash tzdata &&\
+    apk --no-cache add curl bash tzdata unzip &&\
     rm -rf /var/cache/apk/* &&\
     cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime &&\
     echo "Asia/Taipei" > /etc/timezone &&\

--- a/git/Dockerfile.2
+++ b/git/Dockerfile.2
@@ -1,4 +1,4 @@
-FROM bitnami/git:2
+FROM bitnamilegacy/git:2
 LABEL maintainer="softleader.com.tw"
 
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md


### PR DESCRIPTION
## 問題背景

2026/7/19 的 GitHub Actions 出現兩類映像建置失敗：

1. `git:2` image 解析 `bitnami/git:2` 時回傳 `not found`，導致建置在載入 base image metadata 階段終止。
2. AdoptOpenJDK 11 Taipei 的 JRE 與 font JRE images 在執行 memory-calculator 安裝腳本時回報 `Download failed`。安裝器處理下載的 ZIP 檔需要 `unzip`，但原本的 Alpine 套件清單沒有安裝它。

## 根因

- `bitnami/git:2` 已無法從原本的 repository 解析，現有 Git 2 legacy image 位於 `bitnamilegacy/git:2`。
- 兩個 AdoptOpenJDK 11 Taipei images 僅安裝下載工具，缺少安裝腳本解壓縮 artifact 所需的 `unzip`。

## 變更內容

- 將 `git/Dockerfile.2` 的 base image 從 `bitnami/git:2` 改為 `bitnamilegacy/git:2`。
- 在 `eclipse-temurin/Dockerfile.11-jre-taipei` 的 Alpine 套件清單加入 `unzip`。
- 在 `eclipse-temurin/Dockerfile.11-font-jre-taipei` 的 Alpine 套件清單加入 `unzip`。
- 沒有修改其他 image、workflow 或應用程式行為。

## 影響

- 恢復 Git 2 image 的 base image 解析與後續工具安裝。
- 恢復兩個 AdoptOpenJDK 11 Taipei images 的 memory-calculator 安裝流程。
- font JRE image 原有的 fontconfig 與 DejaVu 字型仍維持可用。

> [!CAUTION]
> `bitnamilegacy` 是封存且不再提供更新的 repository。本次依目前建置需求恢復 CI；後續仍建議另行評估可持續維護的 Git base image。

## 驗證

- [x] 修改前重現 `bitnami/git:2: not found`。
- [x] 修改前重現兩個 JDK11 images 的 memory-calculator installer `Download failed`。
- [x] 三個 Dockerfiles 均以 `linux/amd64 --pull --no-cache --load` 完整建置成功。
- [x] Git image 執行期確認 `git 2.50.0`、`gh 2.96.0`、GNU Make、`jq` 與 Info-ZIP 可執行。
- [x] JDK11 JRE image 執行期確認 `/usr/bin/unzip`、Info-ZIP 6.00、memory-calculator 1.2.6 與 executable entrypoint。
- [x] JDK11 font JRE image通過相同檢查，並確認 DejaVu 字型仍可由 `fc-list` 取得。
- [x] `git diff --check` 通過；變更範圍只有三個目標 Dockerfiles，共 3 insertions、3 deletions。
- [x] 驗證使用的暫存 images 與 buildx builder 已清除。

## 提交

- `add5c2820340cc56096a69cc3e8a19ed44cd8bf3` — `fix: repair GitHub Actions image builds`
